### PR TITLE
fix: check if path is dir before treat is a dir

### DIFF
--- a/iniconf/config.py
+++ b/iniconf/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from os import listdir
-from os.path import isfile, join
+from os.path import isdir, isfile, join
 from iniconf.libs import utils
 from iniconf.base import BaseParser
 
@@ -16,7 +16,7 @@ class Config:
         for path in self.config_paths:
             if isfile(path):
                 self.config_files.append(path)
-            else:
+            elif isdir(path):
                 files = [f for f in listdir(path) if isfile(join(path, f)) and f.lower().endswith('.ini')]
                 files.sort()
                 self.config_files += files


### PR DESCRIPTION
It´s necessary for cases like:

```python
Config(['/etc/x-confs/global.ini',
        '/etc/x-confs/specific-project.ini'])
```

If `/etc/companyX/specific-project.ini` file does not exist, it cannot be be treated as a dir.